### PR TITLE
fix(article): fix the link to edit the content in github

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -10,7 +10,7 @@
     {{ end }}
   </h1>
   {{- if .Site.Params.github_repo_edit -}}
-    <a class="article-edit flex-none i-md" href="{{ $.Site.Params.github_repo_edit }}/{{ .Page.File.Path | replaceRE `\\` "/" }}" data-tts="down-right" aria-label="{{ i18n "edit_on_github" }}">
+    <a class="article-edit flex-none i-md" href="{{ $.Site.Params.github_repo_edit }}/{{ .Page.Path | replaceRE `\\` "/" }}" data-tts="down-right" aria-label="{{ i18n "edit_on_github" }}">
       {{ partial "svg" (dict "icon" "pencil") }}
     </a>
   {{- end -}}


### PR DESCRIPTION
When using the configuration `github_repo_edit`, it led me to the following error:

```
ERROR render of "/categories" failed: "[...]/docs/themes/docs/layouts/_default/baseof.html:21:15": execute of template failed: template: list.html:21:15: executing "main" at <partial "article" .>: error calling partial: "[...]/docs/themes/docs/layouts/partials/article.html:13:94": execute of template failed: template: _partials/article.html:13:94: executing "_partials/article.html" at <.Page.File.Path>: error calling Path: runtime error: invalid memory address or nil pointer dereference
Built in 90 ms
Error: error building site: render: failed to render pages: render of "/tags" failed: "[...]/docs/themes/docs/layouts/_default/baseof.html:21:15": execute of template failed: template: list.html:21:15: executing "main" – File is nil; wrap it in if or with: {{ with partial "article" .>: error calling partial: "[...]/docs/themes/docs/layouts/partials/article.html:13:94": execute of template failed: template: _partials/article.html:13:94: executing "_partials/article.html" at <.Page.File }}{{ .Path }}{{ end }}

```

I am running the theme with hugo v0.147.4-84c8426f328a946b2e10611431c450b352cecd11+extended linux/amd64. As the `.Page` package and `.Page.File` method has been pretty stable through the past version, I suppose it is not related to the version. The proposed change fixes the issue. 
