### PR TITLE
feat(head): add the site title along the page title

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,13 +1,13 @@
 
 <meta charset="UTF-8"/>
-<meta content='width=device-width,initial-scale=1' name='viewport'/>
+<meta content="width=device-width,initial-scale=1" name="viewport"/>
 
-<title>{{ partial "title" . }}</title>
-<meta name="description" content="{{ .Page.Params.description | default .Site.Params.description }}">
-<link rel="icon" href='{{ "favicon.svg" | relURL }}' type="image/svg+xml">
+<title>{{ partial "title" . }} {{ if not .IsHome }} | {{ .Site.Title }} {{ end }}</title>
+<meta name="description" content="{{ .Page.Params.description | default .Site.Params.description }}"/>
+<link rel="icon" href='{{ "favicon.svg" | relURL }}' type="image/svg+xml"/>
 
 {{- range .Translations }}
-<link rel="alternate" hreflang="{{ default .Site.LanguageCode .Language.Lang }}" href="{{ .Permalink }}">
+<link rel="alternate" hreflang="{{ default .Site.LanguageCode .Language.Lang }}" href="{{ .Permalink }}"/>
 {{- end -}}
 
 {{- $script := resources.Get "js/dark.js" | resources.Minify -}}


### PR DESCRIPTION
For accessibility reason and to help users know better the website behind a tab name, it is preferred to add the site title along to the page title.